### PR TITLE
Remove stemmer filter in the search to better support strict search

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -84,7 +84,6 @@ plugins:
       lang: en
       separator: '[\s\-,:!=\[\]()"/]+|(?!\b)(?=[A-Z][a-z])|\.(?!\d)|&[lg]t;'
       pipeline:
-        - stemmer
         - stopWordFilter
         - trimmer
 


### PR DESCRIPTION
When searching for the keyword `staging`, no results are returned if the filter is enabled. This appears to be due to the term being translated or normalized to stage.

Observed behavior:
* Searching for `staging`: returns 0 results
* Searching for `stage`:  returns both stage and staging results

This behavior is problematic since `staging` is a common technical term in documentation, and users expect it to return relevant results directly.
